### PR TITLE
Fix: checking for empty list before looking if file is readable

### DIFF
--- a/autoload/git_switcher/project_prev_branch.vim
+++ b/autoload/git_switcher/project_prev_branch.vim
@@ -32,7 +32,7 @@ fun! git_switcher#project_prev_branch#new(project_key, branch_key) abort
   fun! l:obj._same_process_file_paths() abort
     let l:file_paths = split(expand(l:self.project_dir.path().'*'.l:self.prev_branch_file.ext()))
 
-    if !filereadable(l:file_paths[0])
+    if empty(l:file_paths) || !filereadable(l:file_paths[0])
       return []
     endif
 

--- a/autoload/git_switcher/project_session.vim
+++ b/autoload/git_switcher/project_session.vim
@@ -41,7 +41,7 @@ fun! git_switcher#project_session#new(project_key, session_key) abort
   fun! l:obj._same_process_lock_file_paths() abort
     let l:lock_file_paths = split(expand(l:self.project_dir.path().'*'.l:self.lock_file.ext()))
 
-    if !filereadable(l:lock_file_paths[0])
+    if empty(l:lock_file_paths) || !filereadable(l:lock_file_paths[0])
       return []
     endif
 
@@ -51,7 +51,7 @@ fun! git_switcher#project_session#new(project_key, session_key) abort
   fun! l:obj._already_existing_lock_file_paths() abort
     let l:lock_file_paths = split(expand(l:self.project_dir.path().l:self.lock_file.glob_name()))
 
-    if !filereadable(l:lock_file_paths[0])
+    if empty(l:lock_file_paths) || !filereadable(l:lock_file_paths[0])
       return []
     endif
 


### PR DESCRIPTION
I had an issue when trying to use GswSave which complained that I tried to access index in an empty list. I traced it to these lines. 

It's simply an added guard, I'm not too familiar with object-oriented design in vimscript so didn't spend a whole lot of time trying to understand the flow, so if you feel this should be checked somewhere else do feel free to specify.