### PR TITLE
Add: Windows support

### DIFF
--- a/autoload/git_switcher/git.vim
+++ b/autoload/git_switcher/git.vim
@@ -11,11 +11,11 @@ fun! git_switcher#git#new() abort
   " private
 
   fun! l:obj._exec_and_return_exit_code(cmd) abort
-    return system('\'.l:self._self.' '.a:cmd.' >/dev/null 2>&1; echo $?')
+    return system('sh -c "'.l:self._self.' '.a:cmd.' >/dev/null 2>&1; echo $?"')
   endf
 
   fun! l:obj._exec_and_return_list_of_splited_stdout_with_exit_code(cmd) abort
-    return split(system('\'.l:self._self.' '.a:cmd.'; echo $?'), "\n")
+    return split(system('sh -c "'.l:self._self.' '.a:cmd.'; echo $?"'), "\n")
   endf
 
   fun! l:obj._exec(cmd) abort

--- a/autoload/git_switcher/git.vim
+++ b/autoload/git_switcher/git.vim
@@ -11,11 +11,11 @@ fun! git_switcher#git#new() abort
   " private
 
   fun! l:obj._exec_and_return_exit_code(cmd) abort
-    return system('sh -c "'.l:self._self.' '.a:cmd.' >/dev/null 2>&1; echo $?"')
+    return system('bash -c "'.l:self._self.' '.a:cmd.' >/dev/null 2>&1; echo $?"')
   endf
 
   fun! l:obj._exec_and_return_list_of_splited_stdout_with_exit_code(cmd) abort
-    return split(system('sh -c "'.l:self._self.' '.a:cmd.'; echo $?"'), "\n")
+    return split(system('bash -c "'.l:self._self.' '.a:cmd.'; echo $?"'), "\n")
   endf
 
   fun! l:obj._exec(cmd) abort


### PR DESCRIPTION
By using sh -c "git ..." we get access to bash utilities such as null device on windows. Since we are already required to have git-for-windows installed, sh and other tools come with it. 

sh -c "git ..." should really not change any behavior on other platforms.

I'm unsure what "\" in front of the command is meant to accomplish, on Windows, it will start screaming that \sh does not exist!

I haven't had a proper look if there are more system calls that need converting, this is more meant as a proof of concept. Let's hear your thoughts.